### PR TITLE
Adds handling for odd number of philos

### DIFF
--- a/philosophers_working/includes/philo.h
+++ b/philosophers_working/includes/philo.h
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/05 16:57:19 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/23 20:17:29 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 15:38:18 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,8 @@ typedef enum e_ret
 typedef struct s_philo
 {
 	int					id;
+	int					num_philo;
+	int					time_to_die;
 	int					time_to_eat;
 	int					time_to_sleep;
 	int					num_tt_eat;
@@ -145,7 +147,7 @@ bool	ft_isdigit(int c);
 
 //	philo_actions.c
 //	static void	ft_philo_sleep(t_philo *philo);
-//	static void	ft_philo_wait(t_philo *philo);
+void	ft_philo_wait(t_philo *philo);
 //	static bool	ft_check_if_philo_dead(t_philo *philo);
 //	static bool	ft_philo_check_num_meals(t_philo *philo);
 void	*ft_pthread_entry_point(void *arg);
@@ -154,8 +156,8 @@ void	*ft_pthread_entry_point(void *arg);
 //	static void	ft_save_last_eat(t_philo *philo)
 //	static void	ft_grab_forks_even(t_philo *philo)
 //	static void	ft_grab_forks_odd(t_philo *philo)
-//	static void	ft_grab_forks(t_philo *philo);
 void	ft_philo_eat(t_philo *philo);
+void	ft_philo_odd_sync(t_philo *philo, int flag);
 
 //	philo_print.c
 void	ft_m_printf(t_info *info, const char *s, t_ms time_stamp, int id);

--- a/philosophers_working/includes/philo.h
+++ b/philosophers_working/includes/philo.h
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/05 16:57:19 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/25 15:38:18 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:48:28 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,11 @@
 */
 
 # define START_DELAY 100
+# define BLUE 34
+# define YELLOW 33
+# define GREEN 32
+# define RED 31
+# define CLEAR 0
 
 /*
 **	TYPEDEFS
@@ -45,6 +50,13 @@ typedef enum e_ret
 	SUCCESS,
 	FAILURE,
 }	t_ret;
+
+typedef struct s_print_info
+{
+	const char	*s;
+	t_ms		time_stamp;
+	int			id;
+}	t_print_info;
 
 /*
 ** l_fork and r_fork are addresses to m_forks in t_info
@@ -160,6 +172,6 @@ void	ft_philo_eat(t_philo *philo);
 void	ft_philo_odd_sync(t_philo *philo, int flag);
 
 //	philo_print.c
-void	ft_m_printf(t_info *info, const char *s, t_ms time_stamp, int id);
+void	ft_m_printf(t_philo *philo, const char *s, t_ms time_stamp);
 
 #endif

--- a/philosophers_working/srcs/main_thread/init_threads.c
+++ b/philosophers_working/srcs/main_thread/init_threads.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/16 16:18:43 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/23 00:52:57 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 15:39:08 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,8 @@ static bool	ft_create_philos(t_info *info)
 		info->philos[i].id = i;
 		info->philos[i].info = info;
 		info->philos[i].last_ate = info->start_time;
+		info->philos[i].num_philo = info->num_philo;
+		info->philos[i].time_to_die = info->time_to_die;
 		info->philos[i].time_to_eat = info->time_to_eat;
 		info->philos[i].time_to_sleep = info->time_to_sleep;
 		if (info->num_tt_eat)

--- a/philosophers_working/srcs/main_thread/monitor.c
+++ b/philosophers_working/srcs/main_thread/monitor.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 15:20:15 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/25 14:44:31 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:44:55 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,8 @@
 
 static void	ft_philo_died(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%ld %d died\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmdied\n",
+		ft_get_time() - philo->info->start_time);
 	pthread_mutex_lock(&philo->info->m_info_data);
 	philo->info->someone_died = 1;
 	pthread_mutex_unlock(&philo->info->m_info_data);

--- a/philosophers_working/srcs/main_thread/monitor.c
+++ b/philosophers_working/srcs/main_thread/monitor.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 15:20:15 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/25 16:44:55 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:55:00 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@
 
 static void	ft_philo_died(t_philo *philo)
 {
-	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmdied\n",
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d died\e[%dm\n",
 		ft_get_time() - philo->info->start_time);
 	pthread_mutex_lock(&philo->info->m_info_data);
 	philo->info->someone_died = 1;

--- a/philosophers_working/srcs/main_thread/monitor.c
+++ b/philosophers_working/srcs/main_thread/monitor.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 15:20:15 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/23 20:00:16 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 14:44:31 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@
 
 static void	ft_philo_died(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%05ld %d died\n",
+	ft_m_printf(philo->info, "%ld %d died\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	pthread_mutex_lock(&philo->info->m_info_data);
 	philo->info->someone_died = 1;

--- a/philosophers_working/srcs/philos/philo_actions.c
+++ b/philosophers_working/srcs/philos/philo_actions.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 15:39:59 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/23 20:23:00 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 15:37:13 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@
 
 static void	ft_philo_sleep(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%05ld %d is sleeping\n",
+	ft_m_printf(philo->info, "%ld %d is sleeping\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	ft_msleep(philo->time_to_sleep);
 	return ;
@@ -38,9 +38,9 @@ static void	ft_philo_sleep(t_philo *philo)
 		Void function does not return a value.
 */
 
-static void	ft_philo_wait(t_philo *philo)
+void	ft_philo_wait(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%05ld %d is thinking\n",
+	ft_m_printf(philo->info, "%ld %d is thinking\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	ft_msleep(1);
 	return ;
@@ -100,8 +100,12 @@ void	*ft_pthread_entry_point(void *arg)
 	philo = arg;
 	pthread_mutex_lock(&philo->info->m_ready);
 	pthread_mutex_unlock(&philo->info->m_ready);
+	if (philo->info->num_philo % 2)
+		ft_philo_odd_sync(philo, 0);
 	while (1)
 	{
+		if (philo->info->num_philo % 2)
+			ft_philo_odd_sync(philo, 1);
 		if (philo->id % 2)
 			ft_philo_wait(philo);
 		ft_philo_eat(philo);
@@ -112,6 +116,8 @@ void	*ft_pthread_entry_point(void *arg)
 			return (0);
 		if (ft_philo_check_num_meals(philo))
 			return (0);
+		if (philo->info->num_philo % 2)
+			ft_philo_odd_sync(philo, 2);
 	}
 	return (0);
 }

--- a/philosophers_working/srcs/philos/philo_actions.c
+++ b/philosophers_working/srcs/philos/philo_actions.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 15:39:59 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/25 15:37:13 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:46:24 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,8 @@
 
 static void	ft_philo_sleep(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%ld %d is sleeping\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmis sleeping\n",
+		ft_get_time() - philo->info->start_time);
 	ft_msleep(philo->time_to_sleep);
 	return ;
 }
@@ -40,8 +40,8 @@ static void	ft_philo_sleep(t_philo *philo)
 
 void	ft_philo_wait(t_philo *philo)
 {
-	ft_m_printf(philo->info, "%ld %d is thinking\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmis thinking\n",
+		ft_get_time() - philo->info->start_time);
 	ft_msleep(1);
 	return ;
 }

--- a/philosophers_working/srcs/philos/philo_eating.c
+++ b/philosophers_working/srcs/philos/philo_eating.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/10 17:19:21 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/25 15:46:35 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:47:03 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,8 +47,8 @@ static void	ft_save_last_eat(t_philo *philo)
 static void	ft_grab_forks_even(t_philo *philo)
 {
 	pthread_mutex_lock(philo->r_fork);
-	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmhas taken a fork\n",
+		ft_get_time() - philo->info->start_time);
 	if (philo->r_fork == philo->l_fork)
 	{
 		pthread_mutex_lock(&philo->m_data);
@@ -59,10 +59,10 @@ static void	ft_grab_forks_even(t_philo *philo)
 		return ;
 	}
 	pthread_mutex_lock(philo->l_fork);
-	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
-		ft_get_time() - philo->info->start_time, philo->id);
-	ft_m_printf(philo->info, "%ld %d is eating\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmhas taken a fork\n",
+		ft_get_time() - philo->info->start_time);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmis eating\n",
+		ft_get_time() - philo->info->start_time);
 	ft_msleep(philo->time_to_eat);
 	ft_save_last_eat(philo);
 	pthread_mutex_unlock(philo->l_fork);
@@ -87,13 +87,13 @@ static void	ft_grab_forks_even(t_philo *philo)
 static void	ft_grab_forks_odd(t_philo *philo)
 {
 	pthread_mutex_lock(philo->l_fork);
-	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmhas taken a fork\n",
+		ft_get_time() - philo->info->start_time);
 	pthread_mutex_lock(philo->r_fork);
-	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
-		ft_get_time() - philo->info->start_time, philo->id);
-	ft_m_printf(philo->info, "%ld %d is eating\n",
-		ft_get_time() - philo->info->start_time, philo->id);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmhas taken a fork\n",
+		ft_get_time() - philo->info->start_time);
+	ft_m_printf(philo, "\e[%dm%05ld \e[%dm%03d \e[%dmis eating\n",
+		ft_get_time() - philo->info->start_time);
 	ft_msleep(philo->time_to_eat);
 	ft_save_last_eat(philo);
 	pthread_mutex_unlock(philo->r_fork);

--- a/philosophers_working/srcs/philos/philo_eating.c
+++ b/philosophers_working/srcs/philos/philo_eating.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/10 17:19:21 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/23 19:45:04 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 15:46:35 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ static void	ft_save_last_eat(t_philo *philo)
 static void	ft_grab_forks_even(t_philo *philo)
 {
 	pthread_mutex_lock(philo->r_fork);
-	ft_m_printf(philo->info, "%05ld %d has taken a fork\n",
+	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	if (philo->r_fork == philo->l_fork)
 	{
@@ -59,9 +59,9 @@ static void	ft_grab_forks_even(t_philo *philo)
 		return ;
 	}
 	pthread_mutex_lock(philo->l_fork);
-	ft_m_printf(philo->info, "%05ld %d has taken a fork\n",
+	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
 		ft_get_time() - philo->info->start_time, philo->id);
-	ft_m_printf(philo->info, "%05ld %d is eating\n",
+	ft_m_printf(philo->info, "%ld %d is eating\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	ft_msleep(philo->time_to_eat);
 	ft_save_last_eat(philo);
@@ -87,12 +87,12 @@ static void	ft_grab_forks_even(t_philo *philo)
 static void	ft_grab_forks_odd(t_philo *philo)
 {
 	pthread_mutex_lock(philo->l_fork);
-	ft_m_printf(philo->info, "%05ld %d has taken a fork\n",
+	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	pthread_mutex_lock(philo->r_fork);
-	ft_m_printf(philo->info, "%05ld %d has taken a fork\n",
+	ft_m_printf(philo->info, "%ld %d has taken a fork\n",
 		ft_get_time() - philo->info->start_time, philo->id);
-	ft_m_printf(philo->info, "%05ld %d is eating\n",
+	ft_m_printf(philo->info, "%ld %d is eating\n",
 		ft_get_time() - philo->info->start_time, philo->id);
 	ft_msleep(philo->time_to_eat);
 	ft_save_last_eat(philo);
@@ -116,4 +116,39 @@ void	ft_philo_eat(t_philo *philo)
 		ft_grab_forks_odd(philo);
 	else
 		ft_grab_forks_even(philo);
+}
+
+/*
+	NAME
+		ft_philo_odd_sync
+	DESCRIPTION
+		Used in the case of an odd number of philosophers.
+		Adds delay times in between transitions to properly manage scheduling.
+	RETURN
+		Only calls waits or sleeps and does not return a value.
+*/
+
+void	ft_philo_odd_sync(t_philo *philo, int flag)
+{
+	if (flag == 0
+		&& philo->id == 0)
+	{
+		ft_philo_wait(philo);
+		ft_msleep(philo->time_to_eat * 2);
+	}
+	if (flag == 1
+		&& philo->id == 0
+		&& philo->p_num_meals != 0)
+	{
+		ft_philo_wait(philo);
+		if (philo->time_to_eat < philo->info->time_to_die
+			- (philo->time_to_sleep + philo->time_to_eat))
+			ft_msleep(philo->time_to_eat);
+	}
+	if (flag == 2
+		&& philo->id != 0
+		&& philo->time_to_eat < philo->info->time_to_die
+		- (philo->time_to_sleep + philo->time_to_eat))
+		ft_msleep(philo->time_to_eat);
+	return ;
 }

--- a/philosophers_working/srcs/philos/philo_print.c
+++ b/philosophers_working/srcs/philos/philo_print.c
@@ -6,7 +6,7 @@
 /*   By: dpentlan <dpentlan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/19 12:45:44 by dpentlan          #+#    #+#             */
-/*   Updated: 2023/10/22 23:26:01 by dpentlan         ###   ########.fr       */
+/*   Updated: 2023/10/25 16:49:09 by dpentlan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,14 +21,17 @@
 		Void function does not return a value.
 */
 
-void	ft_m_printf(t_info *info, const char *s, t_ms time_stamp, int id)
+void	ft_m_printf(t_philo *philo, const char *s, t_ms time_stamp)
 {
-	pthread_mutex_lock(&info->m_info_data);
-	if (!info->someone_died)
+	pthread_mutex_lock(&philo->info->m_info_data);
+	if (!philo->info->someone_died)
 	{
-		pthread_mutex_lock(&info->m_printf);
-		printf(s, time_stamp, id + 1);
-		pthread_mutex_unlock(&info->m_printf);
+		pthread_mutex_lock(&philo->info->m_printf);
+		if (philo->id % 2)
+			printf(s, YELLOW, time_stamp, GREEN, philo->id + 1, CLEAR);
+		else
+			printf(s, YELLOW, time_stamp, RED, philo->id + 1, CLEAR);
+		pthread_mutex_unlock(&philo->info->m_printf);
 	}
-	pthread_mutex_unlock(&info->m_info_data);
+	pthread_mutex_unlock(&philo->info->m_info_data);
 }


### PR DESCRIPTION
Adds odd philos by adding a function called ft_philo_odd_sync. This adds delays to steps depending on various conditions resulting in properly spaced eating times.
Without this, some philos will grab forks too soon and block out others resulting in starving philos.